### PR TITLE
Fixed warning error when there are comments in media queries

### DIFF
--- a/tasks/combine_media_queries.js
+++ b/tasks/combine_media_queries.js
@@ -105,7 +105,9 @@ module.exports = function(grunt) {
             
             // push every single of merged query
             rule.rules.forEach(function (mediaRule) {
-              processedCSS.media[i].rules.push(mediaRule);
+              if (mediaRule.type === 'rule') {
+                processedCSS.media[i].rules.push(mediaRule);
+              }
             });
 
           } else if (rule.type === 'keyframes') {


### PR DESCRIPTION
If there are comments in media queries, this task fails with the following warning: "Warning: Cannot call method 'join' of undefined".

This pull request fixes that. 
