### PR TITLE
Support dynamic mapping

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,6 +28,12 @@ module.exports = function(grunt) {
         files: {
           'tmp': ['test/test3.css']
         }
+      },
+      dynamic: {
+        expand: true,
+        cwd: 'test/',
+        src: ['test6.css'],
+        dest: 'tmp/'
       }
     }
 

--- a/tasks/combine_media_queries.js
+++ b/tasks/combine_media_queries.js
@@ -123,8 +123,13 @@ module.exports = function(grunt) {
       
         log('\nFile ' + filepath + ' found.');
               
+        var destpath = f.dest;
         var filename = filepath.replace(/(.*)\//gi, '');
-        var destpath = path.join(f.dest, filename);
+
+        if (destpath.indexOf(filename) === -1) {
+          destpath = path.join(f.dest, filename);
+        }
+
         var source = grunt.file.read(filepath);
         var cssJson = parseCss(source);
         var strStyles = [];

--- a/test/test6.css
+++ b/test/test6.css
@@ -1,0 +1,79 @@
+.foo {
+  color: #001;
+}
+
+@media (min-width: 640px) {
+  .foo {
+    color: #100;
+  }
+}
+
+.bar {
+  color: #002;
+}
+
+@media (min-width: 960px) {
+  .bar {
+    color: #200;
+  }
+}
+
+.baz {
+  color: #003;
+}
+
+@media (min-width: 640px) {
+  .baz {
+    color: #300;
+  }
+}
+
+.qux {
+  color: #004;
+}
+
+@media (min-width: 640px) {
+  .qux {
+    color: #400;
+  }
+}
+
+.quux {
+  color: #005;
+}
+
+@media (min-width: 960px) {
+  .quux {
+    color: #500;
+  }
+}
+
+.corge {
+  color: #006;
+}
+
+@media (min-width: 960px) {
+  .corge {
+    color: #600;
+  }
+}
+
+.grault {
+  color: #007;
+}
+
+@media (min-width: 640px) {
+  .grault {
+    color: #700;
+  }
+}
+
+.garply {
+  color: #008;
+}
+
+@media (min-width: 960px) {
+  .garply {
+    color: #800;
+  }
+}


### PR DESCRIPTION
This plugin creates destination files' path with special treatment. It's
not a Grunt way. I rewrite to use `dest` correctly for dynamic mapping
and added small ad-hoc codes for backward compatibility.

Seealso: http://gruntjs.com/configuring-tasks#building-the-files-object-dynamically
