### PR TITLE
Improve ordering of media queries

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
       dynamic: {
         expand: true,
         cwd: 'test/',
-        src: ['test6.css'],
+        src: ['*.css'],
         dest: 'tmp/'
       }
     }

--- a/tasks/combine_media_queries.js
+++ b/tasks/combine_media_queries.js
@@ -198,11 +198,7 @@ module.exports = function(grunt) {
           
         // Sort media queries by kind, this is needed to output them in the right order
         processedCSS.media.forEach(function (item) {
-          if (item.rule.match( /print/ )){
-            processedCSS.media.print.push(item);  
-          } else if (item.rule.match( /all/ )){
-            processedCSS.media.all.push(item);
-          } else if (item.rule.match( /min-width/ )){
+          if (item.rule.match( /min-width/ )){
             processedCSS.media.minWidth.push(item);
           } else if (item.rule.match( /min-height/ )){
             processedCSS.media.minHeight.push(item);
@@ -210,6 +206,10 @@ module.exports = function(grunt) {
             processedCSS.media.maxWidth.push(item);
           } else if (item.rule.match( /max-height/ )){
             processedCSS.media.maxHeight.push(item);
+          } else if (item.rule.match( /print/ )){
+            processedCSS.media.print.push(item);  
+          } else if (item.rule.match( /all/ )){
+            processedCSS.media.all.push(item);
           } else {
             processedCSS.media.blank.push(item); 
           }   

--- a/tasks/combine_media_queries.js
+++ b/tasks/combine_media_queries.js
@@ -215,29 +215,54 @@ module.exports = function(grunt) {
           }   
         });
         
+        // Function to determine sort order
+        var determineSortOrder = function(a, b, isMax) {
+          var sortValA = a.sortVal,
+              sortValB = b.sortVal;
+              isMax = typeof isMax !== 'undefined' ? isMax : false;
+
+          // consider print for sorting if sortVals are equal
+          if (sortValA === sortValB) {
+            if (a.rule.match( /print/ )) {
+              // a contains print and should be sorted after b
+              return 1;
+            }
+            if (b.rule.match( /print/ )) {
+              // b contains print and should be sorted after a
+              return -1;
+            }
+          }
+
+          // return descending sort order for max-(width|height) media queries
+          if (isMax) { return sortValB-sortValA; }
+
+          // return ascending sort order
+          return sortValA-sortValB;
+        };
+        
         // Sort media.all queries ascending
         processedCSS.media.all.sort(function(a,b){
-          return a.sortVal-b.sortVal;
+          return determineSortOrder(a, b);
         });
 
         // Sort media.minWidth queries ascending
         processedCSS.media.minWidth.sort(function(a,b){
-          return a.sortVal-b.sortVal;
+          return determineSortOrder(a, b);
         });
         
         // Sort media.minHeight queries ascending
         processedCSS.media.minHeight.sort(function(a,b){
-          return a.sortVal-b.sortVal;
+          return determineSortOrder(a, b);
         });
         
         // Sort media.maxWidth queries descending
         processedCSS.media.maxWidth.sort(function(a,b){
-          return b.sortVal-a.sortVal;
+          return determineSortOrder(a, b, true);
         });
         
         // Sort media.maxHeight queries descending
         processedCSS.media.maxHeight.sort(function(a,b){
-          return b.sortVal-a.sortVal;
+          return determineSortOrder(a, b, true);
         });
         
         // Function to output base CSS

--- a/test/test7.css
+++ b/test/test7.css
@@ -1,0 +1,129 @@
+@media print, only screen and (min-width: 28em) {
+	.test {
+		color: red;
+	}
+}
+
+@media print, only screen and (min-width: 46em) {
+	.test {
+		color: red;
+	}
+}
+
+@media print, only screen and (min-width: 61em) {
+	.test {
+		color: red;
+	}
+}
+
+@media print, only screen and (max-width: 61em) {
+	.test {
+		color: red;
+	}
+}
+
+@media only screen and (max-width: 45em) {
+	.test {
+		color: red;
+	}
+}
+
+@media only screen and (min-width: 28em) {
+	.test {
+		color: red;
+	}
+}
+
+@media only screen and (min-width: 46em) {
+	.test {
+		color: red;
+	}
+}
+
+@media only screen and (min-width: 61em) {
+	.test {
+		color: red;
+	}
+}
+
+@media only screen and (max-width: 61em) {
+	.test {
+		color: red;
+	}
+}
+
+@media print {
+	.test {
+		color: red;
+	}
+}
+
+@media screen {
+	.test {
+		color: red;
+	}
+}
+
+@media all {
+	.test {
+		color: red;
+	}
+}
+
+@media only screen {
+	.test {
+		color: red;
+	}
+}
+
+@media only print {
+	.test {
+		color: red;
+	}
+}
+
+@media print {
+	.test {
+		color: red;
+	}
+}
+
+@media print {
+	.test {
+		color: red;
+	}
+}
+
+@media print {
+	.test {
+		color: red;
+	}
+}
+
+.test {
+	color: red;
+}
+
+@media (max-width: 45em) {
+	.test {
+		color: red;
+	}
+}
+
+@media (min-width: 28em) {
+	.test {
+		color: red;
+	}
+}
+
+@media (min-width: 46em) {
+	.test {
+		color: red;
+	}
+}
+
+@media (min-width: 61em) {
+	.test {
+		color: red;
+	}
+}

--- a/test/test7.css
+++ b/test/test7.css
@@ -70,6 +70,18 @@
 	}
 }
 
+@media print, only screen and (min-width: 46em) and (max-width: 61em) {
+	.test {
+		color: red;
+	}
+}
+
+@media only screen and (min-width: 46em) and (max-width: 61em) {
+	.test {
+		color: red;
+	}
+}
+
 @media only screen {
 	.test {
 		color: red;


### PR DESCRIPTION
I know (hope) this is a rather rare issue but I need it in a project that has a print layout with lots of styles from all kinds of media queries. I detected a bug when working with media queries that are considered for print and screen combined with a (min|max)-(width|height) e.g.:

``` css
@media print, only screen and (min-width: 60em) { }
```

These were immediately detected as print and put at the end of the file without being sorted. I think the first thing to look for should always be (min|max)-(width|height). I also added a function to sort the (min|max)-(width|height) queries with the same values depending on the keyword print.

There is a test file (test7.css) that demonstrates this.

Cheers,
Daniel
