### PR TITLE
Remove unnecessary `css-parse` dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,13 +58,11 @@
   "devDependencies": {
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-clean": "~0.4.0",
-    "css-parse": "~1.5.0",
     "grunt": "~0.4.2",
     "grunt-release": "~0.7.0"
   },
   "peerDependencies": {
-    "grunt": "~0.4.1",
-    "css-parse": "~1.5.0"
+    "grunt": "~0.4.1"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
- Specifying same module in `dependencies` and `devDependencies` is meaningless
- `peerDependencies` is only for plugging in

By this change, `npm install` will install `css-parse` as child of `grunt-combine-media-queries` only.

This closes #10.
