### PR TITLE
Resolves issue where empty files cause cmq to fail

### DIFF
--- a/tasks/combine-media-queries.js
+++ b/tasks/combine-media-queries.js
@@ -139,7 +139,7 @@ module.exports = function(grunt) {
 
         var source = grunt.file.read(filepath);
         var cssJson = parseCss(source);
-        var strStyles = [];
+        var strStyles = '';
         var processedCSS = {};
         processedCSS.importURL = [];
         processedCSS.base = [];


### PR DESCRIPTION
Although [] + '' -> '', in some cases strStyles remained as [] when grunt.util.normalizelf(strStyles); was invoked, causing an error.

Replaces strStyles with '' by default so that cmq now works with empty files, resolving https://github.com/buildingblocks/grunt-combine-media-queries/issues/16
